### PR TITLE
Avoid namespace ambiguity

### DIFF
--- a/clients/roscpp/include/ros/internal/condition_variable.h
+++ b/clients/roscpp/include/ros/internal/condition_variable.h
@@ -103,11 +103,11 @@ public:
       boost::unique_lock<boost::mutex> &lock,
       const boost::chrono::time_point<boost::chrono::steady_clock, Duration> &t)
   {
-    using namespace boost::chrono;
-    typedef time_point<steady_clock, nanoseconds> nano_sys_tmpt;
+    namespace C = boost::chrono;
+    typedef C::time_point<C::steady_clock, C::nanoseconds> nano_sys_tmpt;
     wait_until(lock,
-               nano_sys_tmpt(ceil<nanoseconds>(t.time_since_epoch())));
-    return steady_clock::now() < t ? boost::cv_status::no_timeout : boost::cv_status::timeout;
+               nano_sys_tmpt(ceil<C::nanoseconds>(t.time_since_epoch())));
+    return C::steady_clock::now() < t ? boost::cv_status::no_timeout : boost::cv_status::timeout;
   }
 
   template <class Clock, class Duration>
@@ -115,10 +115,10 @@ public:
       boost::unique_lock<boost::mutex> &lock,
       const boost::chrono::time_point<Clock, Duration> &t)
   {
-    using namespace boost::chrono;
-    steady_clock::time_point s_now = steady_clock::now();
+    namespace C = boost::chrono;
+    C::steady_clock::time_point s_now = C::steady_clock::now();
     typename Clock::time_point c_now = Clock::now();
-    wait_until(lock, s_now + ceil<nanoseconds>(t - c_now));
+    wait_until(lock, s_now + ceil<C::nanoseconds>(t - c_now));
     return Clock::now() < t ? boost::cv_status::no_timeout : boost::cv_status::timeout;
   }
 
@@ -127,18 +127,18 @@ public:
       boost::unique_lock<boost::mutex> &lock,
       const boost::chrono::duration<Rep, Period> &d)
   {
-    using namespace boost::chrono;
-    steady_clock::time_point c_now = steady_clock::now();
-    wait_until(lock, c_now + ceil<nanoseconds>(d));
-    return steady_clock::now() - c_now < d ? boost::cv_status::no_timeout : boost::cv_status::timeout;
+    namespace C = boost::chrono;
+    C::steady_clock::time_point c_now = C::steady_clock::now();
+    wait_until(lock, c_now + ceil<C::nanoseconds>(d));
+    return C::steady_clock::now() - c_now < d ? boost::cv_status::no_timeout : boost::cv_status::timeout;
   }
 
   boost::cv_status wait_until(
       boost::unique_lock<boost::mutex> &lk,
       boost::chrono::time_point<boost::chrono::steady_clock, boost::chrono::nanoseconds> tp)
   {
-    using namespace boost::chrono;
-    nanoseconds d = tp.time_since_epoch();
+    namespace C = boost::chrono;
+    C::nanoseconds d = tp.time_since_epoch();
     timespec ts = boost::detail::to_timespec(d);
     if (do_wait_until(lk, ts))
       return boost::cv_status::no_timeout;


### PR DESCRIPTION
Hi,

thanks for sharing the patch. I'm trying it locally.

However, I've faced issues compiling one existing node with the patched roscpp: the node defines a `time_point` at global scope and later, when `condition_variable.h` is included through a chain of other include files, we have an ambiguity there.

It sure is not good practice to have stuff at global scope but still, to avoid the issue for others, I'd propose to get rid of 'using namespace boost::chrono;' in favor of a namespace alias.

Guess I just learned that even scoped 'using namespace ...' is not great for use in header files, since the environment we're compiling in is controlled by the includer.

Best Regards

-Felix